### PR TITLE
Refactor the driver to provide a standard SPI driver interface.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,16 +1,26 @@
 # st7789
 
-This is a Rust library for displays using the ST7789 driver with embedded_graphics, embedded_hal, and no_std, no_alloc support. Documentation is available [here](https://docs.rs/st7789). Examples are [here](https://github.com/almindor/st7789-examples)
+This is a Rust driver library for ST7789 displays using embedded_graphics, embedded_hal, and no_std, no_alloc support. 
+- [Driver documentation](https://docs.rs/st7789). 
+- [Examples](https://github.com/almindor/st7789-examples)
+- [Display datasheet](https://www.rhydolabz.com/documents/33/ST7789.pdf)
 
 [![ferris-demo](http://objdump.katona.me/ferris_fast.png)](http://objdump.katona.me/ferris_fast.mp4)
 
 ## Features
 
-These features are enabled by default
+These features are enabled by default:
 
-* `graphics` - embedded-graphics support, pulls in [embedded-graphics](https://crates.io/crates/embedded-graphics) dependency
-* `batch` - batch-drawing optimization, pulls in [heapless](https://crates.io/crates/heapless) dependency and allocates 300 bytes for frame buffer in the driver
+* `graphics` - embedded-graphics support: pulls in [embedded-graphics](https://crates.io/crates/embedded-graphics) dependency
+* `batch` - batch-drawing optimization: pulls in [heapless](https://crates.io/crates/heapless) dependency and allocates 300 bytes for frame buffer in the driver
 * `buffer` - use a 128 byte buffer for SPI data transfers
+
+## Status
+
+- [x] Communications via SPI
+- [x] Tested with PineTime watch
+- [ ] Offscreen Buffering
+- [ ] Hardware scrolling support
 
 ## Changelog
 
@@ -19,6 +29,3 @@ These features are enabled by default
 * `v0.2.0` - batch support
 * `v0.1.0` - initial release
 
-## Roadmap
-
-* `vTBD`   - hardware scolling support

--- a/src/batch.rs
+++ b/src/batch.rs
@@ -6,37 +6,29 @@ use embedded_graphics::{
     pixelcolor::{raw::RawU16, Rgb565},
     prelude::*,
 };
-use embedded_hal::{
-    blocking::{delay::DelayUs, spi},
-    digital::v2::OutputPin,
-};
+use embedded_hal::{blocking::spi, digital::v2::OutputPin};
 
-pub trait DrawBatch<SPI, DC, RST, DELAY, T>
+pub trait DrawBatch<SPI, CSX, DC, RST, T, SPIE, PinE>
 where
-    SPI: spi::Write<u8>,
-    DC: OutputPin,
-    RST: OutputPin,
-    DELAY: DelayUs<u32>,
+    SPI: spi::Write<u8, Error = SPIE>,
+    CSX: OutputPin<Error = PinE>,
+    DC: OutputPin<Error = PinE>,
+    RST: OutputPin<Error = PinE>,
     T: IntoIterator<Item = Pixel<Rgb565>>,
 {
-    fn draw_batch(
-        &mut self,
-        item_pixels: T,
-    ) -> Result<(), Error<SPI::Error, DC::Error, RST::Error>>;
+    fn draw_batch(&mut self, item_pixels: T) -> Result<(), Error<SPIE, PinE>>;
 }
 
-impl<SPI, DC, RST, DELAY, T> DrawBatch<SPI, DC, RST, DELAY, T> for ST7789<SPI, DC, RST, DELAY>
+impl<SPI, CSX, DC, RST, T, SPIE, PinE> DrawBatch<SPI, CSX, DC, RST, T, SPIE, PinE>
+    for ST7789<SPI, CSX, DC, RST>
 where
-    SPI: spi::Write<u8>,
-    DC: OutputPin,
-    RST: OutputPin,
-    DELAY: DelayUs<u32>,
+    SPI: spi::Write<u8, Error = SPIE>,
+    CSX: OutputPin<Error = PinE>,
+    DC: OutputPin<Error = PinE>,
+    RST: OutputPin<Error = PinE>,
     T: IntoIterator<Item = Pixel<Rgb565>>,
 {
-    fn draw_batch(
-        &mut self,
-        item_pixels: T,
-    ) -> Result<(), Error<SPI::Error, DC::Error, RST::Error>> {
+    fn draw_batch(&mut self, item_pixels: T) -> Result<(), Error<SPIE, PinE>> {
         //  Get the pixels for the item to be rendered.
         let pixels = item_pixels.into_iter();
         //  Batch the pixels into Pixel Rows.

--- a/src/graphics.rs
+++ b/src/graphics.rs
@@ -7,24 +7,23 @@ use embedded_graphics::prelude::{DrawTarget, Size};
 use embedded_graphics::primitives::Rectangle;
 use embedded_graphics::style::{PrimitiveStyle, Styled};
 
-use embedded_hal::blocking::delay::DelayUs;
 use embedded_hal::blocking::spi;
 use embedded_hal::digital::v2::OutputPin;
 
 use crate::{Error, ST7789};
 
-impl<SPI, DC, RST, DELAY> ST7789<SPI, DC, RST, DELAY>
+impl<SPI, CSX, DC, RST, SPIE, PinE> ST7789<SPI, CSX, DC, RST>
 where
-    SPI: spi::Write<u8>,
-    DC: OutputPin,
-    RST: OutputPin,
-    DELAY: DelayUs<u32>,
+    SPI: spi::Write<u8, Error = SPIE>,
+    CSX: OutputPin<Error = PinE>,
+    DC: OutputPin<Error = PinE>,
+    RST: OutputPin<Error = PinE>,
 {
     fn fill_rect(
         &mut self,
         item: &dyn Dimensions,
         colors: &mut dyn Iterator<Item = u16>,
-    ) -> Result<(), Error<SPI::Error, DC::Error, RST::Error>> {
+    ) -> Result<(), Error<SPIE, PinE>> {
         let sx = item.top_left().x as u16;
         let sy = item.top_left().y as u16;
         let ex = item.bottom_right().x as u16;
@@ -34,14 +33,14 @@ where
     }
 }
 
-impl<SPI, DC, RST, DELAY> DrawTarget<Rgb565> for ST7789<SPI, DC, RST, DELAY>
+impl<SPI, CSX, DC, RST, SPIE, PinE> DrawTarget<Rgb565> for ST7789<SPI, CSX, DC, RST>
 where
-    SPI: spi::Write<u8>,
-    DC: OutputPin,
-    RST: OutputPin,
-    DELAY: DelayUs<u32>,
+    SPI: spi::Write<u8, Error = SPIE>,
+    CSX: OutputPin<Error = PinE>,
+    DC: OutputPin<Error = PinE>,
+    RST: OutputPin<Error = PinE>,
 {
-    type Error = Error<SPI::Error, DC::Error, RST::Error>;
+    type Error = Error<SPIE, PinE>;
 
     fn draw_pixel(&mut self, pixel: Pixel<Rgb565>) -> Result<(), Self::Error> {
         let color = RawU16::from(pixel.1).into_inner();

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -23,15 +23,18 @@ mod batch;
 ///
 /// ST7789 driver to connect to TFT displays.
 ///
-pub struct ST7789<SPI, DC, RST, DELAY>
+pub struct ST7789<SPI, CSX, DC, RST>
 where
     SPI: spi::Write<u8>,
+    CSX: OutputPin,
     DC: OutputPin,
     RST: OutputPin,
-    DELAY: DelayUs<u32>,
 {
     // SPI
     spi: SPI,
+
+    // Chip select pin
+    csx: CSX,
 
     // Data/command pin.
     dc: DC,
@@ -42,9 +45,6 @@ where
     // Screen size
     size_x: u16,
     size_y: u16,
-
-    // Delay provider
-    delay: DELAY,
 }
 
 ///
@@ -62,18 +62,18 @@ pub enum Orientation {
 /// An error holding its source (pins or SPI)
 ///
 #[derive(Debug)]
-pub enum Error<SPIE, DCE, RSTE> {
+pub enum Error<SPIE, PinE> {
     Spi(SPIE),
-    Dc(DCE),
-    Rst(RSTE),
+    Pin(PinE),
 }
 
-impl<SPI, DC, RST, DELAY> ST7789<SPI, DC, RST, DELAY>
+// impl<SPI, CSX, DC, RST, SPIE, PinE> ST7789<SPI, CSX, DC, RST, SPIE, PinE>
+impl<SPI, CSX, DC, RST, SPIE, PinE> ST7789<SPI, CSX, DC, RST>
 where
-    SPI: spi::Write<u8>,
-    DC: OutputPin,
-    RST: OutputPin,
-    DELAY: DelayUs<u32>,
+    SPI: spi::Write<u8, Error = SPIE>,
+    CSX: OutputPin<Error = PinE>,
+    DC: OutputPin<Error = PinE>,
+    RST: OutputPin<Error = PinE>,
 {
     ///
     /// Creates a new ST7789 driver instance
@@ -81,54 +81,57 @@ where
     /// # Arguments
     ///
     /// * `spi` - an SPI interface to use for talking to the display
+    /// * `csx` - the chip select pin documented in the datasheet
     /// * `dc` - data/clock pin switch
     /// * `rst` - display hard reset pin
     /// * `size_x` - x axis resolution of the display in pixels
     /// * `size_y` - y axis resolution of the display in pixels
-    /// * `delay` - delay provider, required for proper RST and DC timings
     ///
-    pub fn new(spi: SPI, dc: DC, rst: RST, size_x: u16, size_y: u16, delay: DELAY) -> Self {
-        ST7789 {
+    pub fn new(spi: SPI, csx: CSX, dc: DC, rst: RST, size_x: u16, size_y: u16) -> Self {
+        Self {
             spi,
+            csx,
             dc,
             rst,
             size_x,
             size_y,
-            delay,
         }
     }
 
     ///
     /// Runs commands to initialize the display
     ///
-    pub fn init(&mut self) -> Result<(), Error<SPI::Error, DC::Error, RST::Error>> {
-        self.hard_reset()?;
+    pub fn init(&mut self, delay_source: &mut impl DelayUs<u32>) -> Result<(), Error<SPIE, PinE>> {
+        self.hard_reset(delay_source)?;
         self.write_command(Instruction::SWRESET, None)?; // reset display
-        self.delay.delay_us(150_000);
+        delay_source.delay_us(150_000);
         self.write_command(Instruction::SLPOUT, None)?; // turn off sleep
-        self.delay.delay_us(10_000);
+        delay_source.delay_us(10_000);
         self.write_command(Instruction::INVOFF, None)?; // turn off invert
         self.write_command(Instruction::MADCTL, Some(&[0b0000_0000]))?; // left -> right, bottom -> top RGB
         self.write_command(Instruction::COLMOD, Some(&[0b0101_0101]))?; // 16bit 65k colors
         self.write_command(Instruction::INVON, None)?; // hack?
-        self.delay.delay_us(10_000);
+        delay_source.delay_us(10_000);
         self.write_command(Instruction::NORON, None)?; // turn on display
-        self.delay.delay_us(10_000);
+        delay_source.delay_us(10_000);
         self.write_command(Instruction::DISPON, None)?; // turn on display
-        self.delay.delay_us(10_000);
+        delay_source.delay_us(10_000);
         Ok(())
     }
 
     ///
     /// Performs a hard reset using the RST pin sequence
     ///
-    pub fn hard_reset(&mut self) -> Result<(), Error<SPI::Error, DC::Error, RST::Error>> {
-        self.rst.set_high().map_err(Error::Rst)?;
-        self.delay.delay_us(10); // ensure the pin change will get registered
-        self.rst.set_low().map_err(Error::Rst)?;
-        self.delay.delay_us(10); // ensure the pin change will get registered
-        self.rst.set_high().map_err(Error::Rst)?;
-        self.delay.delay_us(10); // ensure the pin change will get registered
+    pub fn hard_reset(
+        &mut self,
+        delay_source: &mut impl DelayUs<u32>,
+    ) -> Result<(), Error<SPIE, PinE>> {
+        self.rst.set_high().map_err(Error::Pin)?;
+        delay_source.delay_us(10); // ensure the pin change will get registered
+        self.rst.set_low().map_err(Error::Pin)?;
+        delay_source.delay_us(10); // ensure the pin change will get registered
+        self.rst.set_high().map_err(Error::Pin)?;
+        delay_source.delay_us(10); // ensure the pin change will get registered
 
         Ok(())
     }
@@ -136,11 +139,9 @@ where
     ///
     /// Sets display orientation
     ///
-    pub fn set_orientation(
-        &mut self,
-        orientation: &Orientation,
-    ) -> Result<(), Error<SPI::Error, DC::Error, RST::Error>> {
-        self.write_command(Instruction::MADCTL, Some(&[orientation.to_u8().unwrap()]))?;
+    pub fn set_orientation(&mut self, orientation: &Orientation) -> Result<(), Error<SPIE, PinE>> {
+        let orientation = orientation.to_u8().unwrap_or(0);
+        self.write_command(Instruction::MADCTL, Some(&[orientation]))?;
         Ok(())
     }
 
@@ -153,12 +154,7 @@ where
     /// * `y` - y coordinate
     /// * `color` - the Rgb565 color value
     ///
-    pub fn set_pixel(
-        &mut self,
-        x: u16,
-        y: u16,
-        color: u16,
-    ) -> Result<(), Error<SPI::Error, DC::Error, RST::Error>> {
+    pub fn set_pixel(&mut self, x: u16, y: u16, color: u16) -> Result<(), Error<SPIE, PinE>> {
         self.set_address_window(x, y, x, y)?;
         self.write_command(Instruction::RAMWR, None)?;
         self.start_data()?;
@@ -183,7 +179,7 @@ where
         ex: u16,
         ey: u16,
         colors: T,
-    ) -> Result<(), Error<SPI::Error, DC::Error, RST::Error>>
+    ) -> Result<(), Error<SPIE, PinE>>
     where
         T: IntoIterator<Item = u16>,
     {
@@ -195,10 +191,7 @@ where
     }
 
     #[cfg(not(feature = "buffer"))]
-    fn write_pixels<T>(
-        &mut self,
-        colors: T,
-    ) -> Result<(), Error<SPI::Error, DC::Error, RST::Error>>
+    fn write_pixels<T>(&mut self, colors: T) -> Result<(), Error<SPI, PinE>>
     where
         T: IntoIterator<Item = u16>,
     {
@@ -210,13 +203,10 @@ where
     }
 
     #[cfg(feature = "buffer")]
-    fn write_pixels<T>(
-        &mut self,
-        colors: T,
-    ) -> Result<(), Error<SPI::Error, DC::Error, RST::Error>>
+    fn write_pixels<T>(&mut self, colors: T) -> Result<(), Error<SPIE, PinE>>
     where
         T: IntoIterator<Item = u16>,
-    { 
+    {
         let mut buf = [0; 128];
         let mut i = 0;
 
@@ -243,9 +233,10 @@ where
         &mut self,
         command: Instruction,
         params: Option<&[u8]>,
-    ) -> Result<(), Error<SPI::Error, DC::Error, RST::Error>> {
-        self.dc.set_low().map_err(Error::Dc)?;
-        self.delay.delay_us(10); // ensure the pin change will get registered
+    ) -> Result<(), Error<SPIE, PinE>> {
+        // select this device on the SPI bus
+        self.csx.set_low().map_err(Error::Pin)?;
+        self.dc.set_low().map_err(Error::Pin)?;
 
         self.spi
             .write(&[command.to_u8().unwrap()])
@@ -255,22 +246,26 @@ where
             self.start_data()?;
             self.write_data(params)?;
         }
-        Ok(())
-    }
-
-    fn start_data(&mut self) -> Result<(), Error<SPI::Error, DC::Error, RST::Error>> {
-        self.dc.set_high().map_err(Error::Dc)?;
-        self.delay.delay_us(10); // ensure the pin change will get registered
+        // clear chip select when done
+        self.csx.set_high().map_err(Error::Pin)?;
 
         Ok(())
     }
 
-    fn write_data(&mut self, data: &[u8]) -> Result<(), Error<SPI::Error, DC::Error, RST::Error>> {
-        self.spi.write(data).map_err(Error::Spi)
+    fn start_data(&mut self) -> Result<(), Error<SPIE, PinE>> {
+        self.dc.set_high().map_err(Error::Pin)?;
+        Ok(())
+    }
+
+    fn write_data(&mut self, data: &[u8]) -> Result<(), Error<SPIE, PinE>> {
+        self.csx.set_low().map_err(Error::Pin)?;
+        self.spi.write(data).map_err(Error::Spi)?;
+        self.csx.set_high().map_err(Error::Pin)?;
+        Ok(())
     }
 
     // Writes a data word to the display.
-    fn write_word(&mut self, value: u16) -> Result<(), Error<SPI::Error, DC::Error, RST::Error>> {
+    fn write_word(&mut self, value: u16) -> Result<(), Error<SPIE, PinE>> {
         self.write_data(&value.to_be_bytes())
     }
 
@@ -281,7 +276,7 @@ where
         sy: u16,
         ex: u16,
         ey: u16,
-    ) -> Result<(), Error<SPI::Error, DC::Error, RST::Error>> {
+    ) -> Result<(), Error<SPIE, PinE>> {
         self.write_command(Instruction::CASET, None)?;
         self.start_data()?;
         self.write_word(sx)?;


### PR DESCRIPTION
Modify the driver's interface to make it usable by embedded/no_std applications in a way similar to other SPI drivers:
- Borrow delay source rather than taking ownership of it
- Take ownership of CSX pin 
- Simplify gpio pin error handling