### PR TITLE
Refactor driver to provide a standard SPI display_interface for embedded hal

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,6 +11,8 @@ readme = "README.md"
 documentation = "https://docs.rs/st7789"
 
 [dependencies]
+display-interface = "0.1.1"
+display-interface-spi = "0.1.0"
 embedded-hal = "0.2"
 nb = "0.1"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,8 +11,8 @@ readme = "README.md"
 documentation = "https://docs.rs/st7789"
 
 [dependencies]
-display-interface = "0.1.1"
-display-interface-spi = "0.1.0"
+display-interface = { version = "0.2" }
+display-interface-spi = "0.2.0"
 embedded-hal = "0.2"
 nb = "0.1"
 

--- a/README.md
+++ b/README.md
@@ -1,16 +1,26 @@
 # st7789
 
-This is a Rust library for displays using the ST7789 driver with embedded_graphics, embedded_hal, and no_std, no_alloc support. Documentation is available [here](https://docs.rs/st7789). Examples are [here](https://github.com/almindor/st7789-examples)
+This is a Rust driver library for ST7789 displays using embedded_graphics, embedded_hal, and no_std, no_alloc support. 
+- [Driver documentation](https://docs.rs/st7789). 
+- [Examples](https://github.com/almindor/st7789-examples)
+- [Display datasheet](https://www.rhydolabz.com/documents/33/ST7789.pdf)
 
 [![ferris-demo](http://objdump.katona.me/ferris_fast.png)](http://objdump.katona.me/ferris_fast.mp4)
 
 ## Features
 
-These features are enabled by default
+These features are enabled by default:
 
-* `graphics` - embedded-graphics support, pulls in [embedded-graphics](https://crates.io/crates/embedded-graphics) dependency
-* `batch` - batch-drawing optimization, pulls in [heapless](https://crates.io/crates/heapless) dependency and allocates 300 bytes for frame buffer in the driver
+* `graphics` - embedded-graphics support: pulls in [embedded-graphics](https://crates.io/crates/embedded-graphics) dependency
+* `batch` - batch-drawing optimization: pulls in [heapless](https://crates.io/crates/heapless) dependency and allocates 300 bytes for frame buffer in the driver
 * `buffer` - use a 128 byte buffer for SPI data transfers
+
+## Status
+
+- [x] Communications via SPI
+- [x] Tested with PineTime watch
+- [ ] Offscreen Buffering
+- [ ] Hardware scrolling support
 
 ## Changelog
 
@@ -19,6 +29,3 @@ These features are enabled by default
 * `v0.2.0` - batch support
 * `v0.1.0` - initial release
 
-## Roadmap
-
-* `vTBD`   - hardware scolling support

--- a/src/batch.rs
+++ b/src/batch.rs
@@ -11,7 +11,7 @@ use embedded_hal::digital::v2::OutputPin;
 
 pub trait DrawBatch<DI, RST, T, PinE>
 where
-    DI: WriteOnlyDataCommand,
+    DI: WriteOnlyDataCommand<u8>,
     RST: OutputPin<Error = PinE>,
     T: IntoIterator<Item = Pixel<Rgb565>>,
 {
@@ -20,7 +20,7 @@ where
 
 impl<DI, RST, T, PinE> DrawBatch<DI, RST, T, PinE> for ST7789<DI, RST>
 where
-    DI: WriteOnlyDataCommand,
+    DI: WriteOnlyDataCommand<u8>,
     RST: OutputPin<Error = PinE>,
     T: IntoIterator<Item = Pixel<Rgb565>>,
 {

--- a/src/batch.rs
+++ b/src/batch.rs
@@ -2,41 +2,29 @@
 //! Batch the pixels to be rendered into Pixel Rows and Pixel Blocks (contiguous Pixel Rows).
 //! This enables the pixels to be rendered efficiently as Pixel Blocks, which may be transmitted in a single Non-Blocking SPI request.
 use crate::{Error, ST7789};
+use display_interface::WriteOnlyDataCommand;
 use embedded_graphics::{
     pixelcolor::{raw::RawU16, Rgb565},
     prelude::*,
 };
-use embedded_hal::{
-    blocking::{delay::DelayUs, spi},
-    digital::v2::OutputPin,
-};
+use embedded_hal::digital::v2::OutputPin;
 
-pub trait DrawBatch<SPI, DC, RST, DELAY, T>
+pub trait DrawBatch<DI, RST, T, PinE>
 where
-    SPI: spi::Write<u8>,
-    DC: OutputPin,
-    RST: OutputPin,
-    DELAY: DelayUs<u32>,
+    DI: WriteOnlyDataCommand,
+    RST: OutputPin<Error = PinE>,
     T: IntoIterator<Item = Pixel<Rgb565>>,
 {
-    fn draw_batch(
-        &mut self,
-        item_pixels: T,
-    ) -> Result<(), Error<SPI::Error, DC::Error, RST::Error>>;
+    fn draw_batch(&mut self, item_pixels: T) -> Result<(), Error<PinE>>;
 }
 
-impl<SPI, DC, RST, DELAY, T> DrawBatch<SPI, DC, RST, DELAY, T> for ST7789<SPI, DC, RST, DELAY>
+impl<DI, RST, T, PinE> DrawBatch<DI, RST, T, PinE> for ST7789<DI, RST>
 where
-    SPI: spi::Write<u8>,
-    DC: OutputPin,
-    RST: OutputPin,
-    DELAY: DelayUs<u32>,
+    DI: WriteOnlyDataCommand,
+    RST: OutputPin<Error = PinE>,
     T: IntoIterator<Item = Pixel<Rgb565>>,
 {
-    fn draw_batch(
-        &mut self,
-        item_pixels: T,
-    ) -> Result<(), Error<SPI::Error, DC::Error, RST::Error>> {
+    fn draw_batch(&mut self, item_pixels: T) -> Result<(), Error<PinE>> {
         //  Get the pixels for the item to be rendered.
         let pixels = item_pixels.into_iter();
         //  Batch the pixels into Pixel Rows.

--- a/src/batch.rs
+++ b/src/batch.rs
@@ -210,8 +210,8 @@ impl<P: Iterator<Item = Pixel<Rgb565>>> Iterator for RowIterator<P> {
                         continue;
                     }
                     //  If this pixel is adjacent to the previous pixel, add to the row.
-                    if x == self.x_right + 1 && y == self.y && self.colors.push(color).is_ok() {
-                        //  Don't add pixel if too many pixels in the row.
+                    if x == self.x_right.wrapping_add(1) && y == self.y && self.colors.push(color).is_ok() {
+                        // Don't add pixel if too many pixels in the row.
                         self.x_right = x;
                         continue;
                     }

--- a/src/graphics.rs
+++ b/src/graphics.rs
@@ -14,7 +14,7 @@ use display_interface::WriteOnlyDataCommand;
 
 impl<DI, RST, PinE> ST7789<DI, RST>
 where
-    DI: WriteOnlyDataCommand,
+    DI: WriteOnlyDataCommand<u8>,
     RST: OutputPin<Error = PinE>,
 {
     fn fill_rect(
@@ -33,7 +33,7 @@ where
 
 impl<DI, RST, PinE> DrawTarget<Rgb565> for ST7789<DI, RST>
 where
-    DI: WriteOnlyDataCommand,
+    DI: WriteOnlyDataCommand<u8>,
     RST: OutputPin<Error = PinE>,
 {
     type Error = Error<PinE>;

--- a/src/graphics.rs
+++ b/src/graphics.rs
@@ -7,24 +7,21 @@ use embedded_graphics::prelude::{DrawTarget, Size};
 use embedded_graphics::primitives::Rectangle;
 use embedded_graphics::style::{PrimitiveStyle, Styled};
 
-use embedded_hal::blocking::delay::DelayUs;
-use embedded_hal::blocking::spi;
 use embedded_hal::digital::v2::OutputPin;
 
 use crate::{Error, ST7789};
+use display_interface::WriteOnlyDataCommand;
 
-impl<SPI, DC, RST, DELAY> ST7789<SPI, DC, RST, DELAY>
+impl<DI, RST, PinE> ST7789<DI, RST>
 where
-    SPI: spi::Write<u8>,
-    DC: OutputPin,
-    RST: OutputPin,
-    DELAY: DelayUs<u32>,
+    DI: WriteOnlyDataCommand,
+    RST: OutputPin<Error = PinE>,
 {
     fn fill_rect(
         &mut self,
         item: &dyn Dimensions,
         colors: &mut dyn Iterator<Item = u16>,
-    ) -> Result<(), Error<SPI::Error, DC::Error, RST::Error>> {
+    ) -> Result<(), Error<PinE>> {
         let sx = item.top_left().x as u16;
         let sy = item.top_left().y as u16;
         let ex = item.bottom_right().x as u16;
@@ -34,14 +31,12 @@ where
     }
 }
 
-impl<SPI, DC, RST, DELAY> DrawTarget<Rgb565> for ST7789<SPI, DC, RST, DELAY>
+impl<DI, RST, PinE> DrawTarget<Rgb565> for ST7789<DI, RST>
 where
-    SPI: spi::Write<u8>,
-    DC: OutputPin,
-    RST: OutputPin,
-    DELAY: DelayUs<u32>,
+    DI: WriteOnlyDataCommand,
+    RST: OutputPin<Error = PinE>,
 {
-    type Error = Error<SPI::Error, DC::Error, RST::Error>;
+    type Error = Error<PinE>;
 
     fn draw_pixel(&mut self, pixel: Pixel<Rgb565>) -> Result<(), Self::Error> {
         let color = RawU16::from(pixel.1).into_inner();

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -10,6 +10,9 @@ use crate::instruction::Instruction;
 use num_derive::ToPrimitive;
 use num_traits::ToPrimitive;
 
+use display_interface_spi::SPIInterface;
+
+use display_interface::WriteOnlyDataCommand;
 use embedded_hal::blocking::delay::DelayUs;
 use embedded_hal::blocking::spi;
 use embedded_hal::digital::v2::OutputPin;
@@ -20,31 +23,50 @@ mod graphics;
 #[cfg(feature = "batch")]
 mod batch;
 
+/// Convenience function for creating a new display driver with SPI
+/// # Arguments
+///
+/// * `spi` - an SPI interface to use for talking to the display
+/// * `csx` - the chip select pin documented in the datasheet
+/// * `dc` - data/clock pin switch
+/// * `rst` - display hard reset pin
+/// * `size_x` - x axis resolution of the display in pixels
+/// * `size_y` - y axis resolution of the display in pixels
+///
+pub fn new_display_driver<SPI, CSX, DC, RST>(
+    spi: SPI,
+    csx: CSX,
+    dc: DC,
+    rst: RST,
+    size_x: u16,
+    size_y: u16,
+) -> ST7789<SPIInterface<SPI, DC, CSX>, RST>
+where
+    SPI: spi::Write<u8>,
+    CSX: OutputPin,
+    DC: OutputPin,
+    RST: OutputPin,
+{
+    let interface = SPIInterface::new(spi, dc, csx);
+    ST7789::new(interface, rst, size_x as u16, size_y as u16)
+}
+
 ///
 /// ST7789 driver to connect to TFT displays.
 ///
-pub struct ST7789<SPI, DC, RST, DELAY>
+pub struct ST7789<DI, RST>
 where
-    SPI: spi::Write<u8>,
-    DC: OutputPin,
+    DI: WriteOnlyDataCommand,
     RST: OutputPin,
-    DELAY: DelayUs<u32>,
 {
-    // SPI
-    spi: SPI,
-
-    // Data/command pin.
-    dc: DC,
-
+    // Display interface
+    di: DI,
     // Reset pin.
     rst: RST,
 
     // Screen size
     size_x: u16,
     size_y: u16,
-
-    // Delay provider
-    delay: DELAY,
 }
 
 ///
@@ -62,18 +84,15 @@ pub enum Orientation {
 /// An error holding its source (pins or SPI)
 ///
 #[derive(Debug)]
-pub enum Error<SPIE, DCE, RSTE> {
-    Spi(SPIE),
-    Dc(DCE),
-    Rst(RSTE),
+pub enum Error<PinE> {
+    DisplayError,
+    Pin(PinE),
 }
 
-impl<SPI, DC, RST, DELAY> ST7789<SPI, DC, RST, DELAY>
+impl<DI, RST, PinE> ST7789<DI, RST>
 where
-    SPI: spi::Write<u8>,
-    DC: OutputPin,
-    RST: OutputPin,
-    DELAY: DelayUs<u32>,
+    DI: WriteOnlyDataCommand,
+    RST: OutputPin<Error = PinE>,
 {
     ///
     /// Creates a new ST7789 driver instance
@@ -81,54 +100,53 @@ where
     /// # Arguments
     ///
     /// * `spi` - an SPI interface to use for talking to the display
+    /// * `di` - a display interface for talking with the display
+    /// * `csx` - the chip select pin documented in the datasheet
     /// * `dc` - data/clock pin switch
     /// * `rst` - display hard reset pin
     /// * `size_x` - x axis resolution of the display in pixels
     /// * `size_y` - y axis resolution of the display in pixels
-    /// * `delay` - delay provider, required for proper RST and DC timings
     ///
-    pub fn new(spi: SPI, dc: DC, rst: RST, size_x: u16, size_y: u16, delay: DELAY) -> Self {
-        ST7789 {
-            spi,
-            dc,
+    pub fn new(di: DI, rst: RST, size_x: u16, size_y: u16) -> Self {
+        Self {
+            di,
             rst,
             size_x,
             size_y,
-            delay,
         }
     }
 
     ///
     /// Runs commands to initialize the display
     ///
-    pub fn init(&mut self) -> Result<(), Error<SPI::Error, DC::Error, RST::Error>> {
-        self.hard_reset()?;
+    pub fn init(&mut self, delay_source: &mut impl DelayUs<u32>) -> Result<(), Error<PinE>> {
+        self.hard_reset(delay_source)?;
         self.write_command(Instruction::SWRESET, None)?; // reset display
-        self.delay.delay_us(150_000);
+        delay_source.delay_us(150_000);
         self.write_command(Instruction::SLPOUT, None)?; // turn off sleep
-        self.delay.delay_us(10_000);
+        delay_source.delay_us(10_000);
         self.write_command(Instruction::INVOFF, None)?; // turn off invert
         self.write_command(Instruction::MADCTL, Some(&[0b0000_0000]))?; // left -> right, bottom -> top RGB
         self.write_command(Instruction::COLMOD, Some(&[0b0101_0101]))?; // 16bit 65k colors
         self.write_command(Instruction::INVON, None)?; // hack?
-        self.delay.delay_us(10_000);
+        delay_source.delay_us(10_000);
         self.write_command(Instruction::NORON, None)?; // turn on display
-        self.delay.delay_us(10_000);
+        delay_source.delay_us(10_000);
         self.write_command(Instruction::DISPON, None)?; // turn on display
-        self.delay.delay_us(10_000);
+        delay_source.delay_us(10_000);
         Ok(())
     }
 
     ///
     /// Performs a hard reset using the RST pin sequence
     ///
-    pub fn hard_reset(&mut self) -> Result<(), Error<SPI::Error, DC::Error, RST::Error>> {
-        self.rst.set_high().map_err(Error::Rst)?;
-        self.delay.delay_us(10); // ensure the pin change will get registered
-        self.rst.set_low().map_err(Error::Rst)?;
-        self.delay.delay_us(10); // ensure the pin change will get registered
-        self.rst.set_high().map_err(Error::Rst)?;
-        self.delay.delay_us(10); // ensure the pin change will get registered
+    pub fn hard_reset(&mut self, delay_source: &mut impl DelayUs<u32>) -> Result<(), Error<PinE>> {
+        self.rst.set_high().map_err(Error::Pin)?;
+        delay_source.delay_us(10); // ensure the pin change will get registered
+        self.rst.set_low().map_err(Error::Pin)?;
+        delay_source.delay_us(10); // ensure the pin change will get registered
+        self.rst.set_high().map_err(Error::Pin)?;
+        delay_source.delay_us(10); // ensure the pin change will get registered
 
         Ok(())
     }
@@ -136,11 +154,9 @@ where
     ///
     /// Sets display orientation
     ///
-    pub fn set_orientation(
-        &mut self,
-        orientation: &Orientation,
-    ) -> Result<(), Error<SPI::Error, DC::Error, RST::Error>> {
-        self.write_command(Instruction::MADCTL, Some(&[orientation.to_u8().unwrap()]))?;
+    pub fn set_orientation(&mut self, orientation: &Orientation) -> Result<(), Error<PinE>> {
+        let orientation = orientation.to_u8().unwrap_or(0);
+        self.write_command(Instruction::MADCTL, Some(&[orientation]))?;
         Ok(())
     }
 
@@ -153,15 +169,9 @@ where
     /// * `y` - y coordinate
     /// * `color` - the Rgb565 color value
     ///
-    pub fn set_pixel(
-        &mut self,
-        x: u16,
-        y: u16,
-        color: u16,
-    ) -> Result<(), Error<SPI::Error, DC::Error, RST::Error>> {
+    pub fn set_pixel(&mut self, x: u16, y: u16, color: u16) -> Result<(), Error<PinE>> {
         self.set_address_window(x, y, x, y)?;
         self.write_command(Instruction::RAMWR, None)?;
-        self.start_data()?;
         self.write_word(color)
     }
 
@@ -183,22 +193,18 @@ where
         ex: u16,
         ey: u16,
         colors: T,
-    ) -> Result<(), Error<SPI::Error, DC::Error, RST::Error>>
+    ) -> Result<(), Error<PinE>>
     where
         T: IntoIterator<Item = u16>,
     {
         self.set_address_window(sx, sy, ex, ey)?;
         self.write_command(Instruction::RAMWR, None)?;
-        self.start_data()?;
 
         self.write_pixels(colors)
     }
 
     #[cfg(not(feature = "buffer"))]
-    fn write_pixels<T>(
-        &mut self,
-        colors: T,
-    ) -> Result<(), Error<SPI::Error, DC::Error, RST::Error>>
+    fn write_pixels<T>(&mut self, colors: T) -> Result<(), Error<SPI, PinE>>
     where
         T: IntoIterator<Item = u16>,
     {
@@ -210,13 +216,10 @@ where
     }
 
     #[cfg(feature = "buffer")]
-    fn write_pixels<T>(
-        &mut self,
-        colors: T,
-    ) -> Result<(), Error<SPI::Error, DC::Error, RST::Error>>
+    fn write_pixels<T>(&mut self, colors: T) -> Result<(), Error<PinE>>
     where
         T: IntoIterator<Item = u16>,
-    { 
+    {
         let mut buf = [0; 128];
         let mut i = 0;
 
@@ -243,34 +246,25 @@ where
         &mut self,
         command: Instruction,
         params: Option<&[u8]>,
-    ) -> Result<(), Error<SPI::Error, DC::Error, RST::Error>> {
-        self.dc.set_low().map_err(Error::Dc)?;
-        self.delay.delay_us(10); // ensure the pin change will get registered
-
-        self.spi
-            .write(&[command.to_u8().unwrap()])
-            .map_err(Error::Spi)?;
+    ) -> Result<(), Error<PinE>> {
+        self.di
+            .send_commands(&[command.to_u8().unwrap()])
+            .map_err(|_| Error::DisplayError)?;
 
         if let Some(params) = params {
-            self.start_data()?;
-            self.write_data(params)?;
+            self.di.send_data(params).map_err(|_| Error::DisplayError)?;
         }
-        Ok(())
-    }
-
-    fn start_data(&mut self) -> Result<(), Error<SPI::Error, DC::Error, RST::Error>> {
-        self.dc.set_high().map_err(Error::Dc)?;
-        self.delay.delay_us(10); // ensure the pin change will get registered
 
         Ok(())
     }
 
-    fn write_data(&mut self, data: &[u8]) -> Result<(), Error<SPI::Error, DC::Error, RST::Error>> {
-        self.spi.write(data).map_err(Error::Spi)
+    fn write_data(&mut self, data: &[u8]) -> Result<(), Error<PinE>> {
+        self.di.send_data(data).map_err(|_| Error::DisplayError)?;
+        Ok(())
     }
 
     // Writes a data word to the display.
-    fn write_word(&mut self, value: u16) -> Result<(), Error<SPI::Error, DC::Error, RST::Error>> {
+    fn write_word(&mut self, value: u16) -> Result<(), Error<PinE>> {
         self.write_data(&value.to_be_bytes())
     }
 
@@ -281,13 +275,11 @@ where
         sy: u16,
         ex: u16,
         ey: u16,
-    ) -> Result<(), Error<SPI::Error, DC::Error, RST::Error>> {
+    ) -> Result<(), Error<PinE>> {
         self.write_command(Instruction::CASET, None)?;
-        self.start_data()?;
         self.write_word(sx)?;
         self.write_word(ex)?;
         self.write_command(Instruction::RASET, None)?;
-        self.start_data()?;
         self.write_word(sy)?;
         self.write_word(ey)
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -56,7 +56,7 @@ where
 ///
 pub struct ST7789<DI, RST>
 where
-    DI: WriteOnlyDataCommand,
+    DI: WriteOnlyDataCommand<u8>,
     RST: OutputPin,
 {
     // Display interface
@@ -91,7 +91,7 @@ pub enum Error<PinE> {
 
 impl<DI, RST, PinE> ST7789<DI, RST>
 where
-    DI: WriteOnlyDataCommand,
+    DI: WriteOnlyDataCommand<u8>,
     RST: OutputPin<Error = PinE>,
 {
     ///
@@ -199,7 +199,6 @@ where
     {
         self.set_address_window(sx, sy, ex, ey)?;
         self.write_command(Instruction::RAMWR, None)?;
-
         self.write_pixels(colors)
     }
 


### PR DESCRIPTION
- Borrow delay source rather than taking ownership of it
- Implement display_interface and provide a builder method
- Take ownership of CSX pin and simplify GPIO pin error handling

