### PR TITLE
Feature/more pin control

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,12 +2,13 @@
 
 ## *unreleased*
 
-* `v0.6.1` - remove unused `buffer` feature
+* introduced control over the backlight pin and made reset pin optional
 
 ## v0.6
 
-* `v0.6.0` - update `embedded-graphics` support to `v0.7`
+* `v0.6.1` - remove unused `buffer` feature
 * `v0.6.1` - optimize `fill_solid` and add tearing effect support
+* `v0.6.0` - update `embedded-graphics` support to `v0.7`
 
 ## v0.5
 

--- a/src/batch.rs
+++ b/src/batch.rs
@@ -9,19 +9,19 @@ use embedded_graphics_core::{
 };
 use embedded_hal::digital::v2::OutputPin;
 
-pub trait DrawBatch<DI, RST, T, PinE>
+pub trait DrawBatch<DI, OUT, T, PinE>
 where
     DI: WriteOnlyDataCommand,
-    RST: OutputPin<Error = PinE>,
+    OUT: OutputPin<Error = PinE>,
     T: IntoIterator<Item = Pixel<Rgb565>>,
 {
     fn draw_batch(&mut self, item_pixels: T) -> Result<(), Error<PinE>>;
 }
 
-impl<DI, RST, T, PinE> DrawBatch<DI, RST, T, PinE> for ST7789<DI, RST>
+impl<DI, OUT, T, PinE> DrawBatch<DI, OUT, T, PinE> for ST7789<DI, OUT>
 where
     DI: WriteOnlyDataCommand,
-    RST: OutputPin<Error = PinE>,
+    OUT: OutputPin<Error = PinE>,
     T: IntoIterator<Item = Pixel<Rgb565>>,
 {
     fn draw_batch(&mut self, item_pixels: T) -> Result<(), Error<PinE>> {

--- a/src/graphics.rs
+++ b/src/graphics.rs
@@ -11,10 +11,10 @@ use embedded_hal::digital::v2::OutputPin;
 use crate::{Error, Orientation, ST7789};
 use display_interface::WriteOnlyDataCommand;
 
-impl<DI, RST, PinE> ST7789<DI, RST>
+impl<DI, OUT, PinE> ST7789<DI, OUT>
 where
     DI: WriteOnlyDataCommand,
-    RST: OutputPin<Error = PinE>,
+    OUT: OutputPin<Error = PinE>,
 {
     /// Returns the bounding box for the entire framebuffer.
     fn framebuffer_bounding_box(&self) -> Rectangle {
@@ -27,10 +27,10 @@ where
     }
 }
 
-impl<DI, RST, PinE> DrawTarget for ST7789<DI, RST>
+impl<DI, OUT, PinE> DrawTarget for ST7789<DI, OUT>
 where
     DI: WriteOnlyDataCommand,
-    RST: OutputPin<Error = PinE>,
+    OUT: OutputPin<Error = PinE>,
 {
     type Error = Error<PinE>;
     type Color = Rgb565;
@@ -128,10 +128,10 @@ where
     }
 }
 
-impl<DI, RST, PinE> OriginDimensions for ST7789<DI, RST>
+impl<DI, OUT, PinE> OriginDimensions for ST7789<DI, OUT>
 where
     DI: WriteOnlyDataCommand,
-    RST: OutputPin<Error = PinE>,
+    OUT: OutputPin<Error = PinE>,
 {
     fn size(&self) -> Size {
         Size::new(self.size_x.into(), self.size_y.into()) // visible area, not RAM-pixel size

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -23,15 +23,17 @@ mod batch;
 ///
 /// ST7789 driver to connect to TFT displays.
 ///
-pub struct ST7789<DI, RST>
+pub struct ST7789<DI, OUT>
 where
     DI: WriteOnlyDataCommand,
-    RST: OutputPin,
+    OUT: OutputPin,
 {
     // Display interface
     di: DI,
     // Reset pin.
-    rst: Option<RST>,
+    rst: Option<OUT>,
+    // Backlight pin,
+    bl: Option<OUT>,
     // Visible size (x, y)
     size_x: u16,
     size_y: u16,
@@ -70,6 +72,12 @@ pub enum TearingEffect {
     HorizontalAndVertical,
 }
 
+#[derive(Copy, Clone, Debug)]
+pub enum BacklightState {
+    On,
+    Off,
+}
+
 ///
 /// An error holding its source (pins or SPI)
 ///
@@ -79,10 +87,10 @@ pub enum Error<PinE> {
     Pin(PinE),
 }
 
-impl<DI, RST, PinE> ST7789<DI, RST>
+impl<DI, OUT, PinE> ST7789<DI, OUT>
 where
     DI: WriteOnlyDataCommand,
-    RST: OutputPin<Error = PinE>,
+    OUT: OutputPin<Error = PinE>,
 {
     ///
     /// Creates a new ST7789 driver instance
@@ -91,13 +99,15 @@ where
     ///
     /// * `di` - a display interface for talking with the display
     /// * `rst` - display hard reset pin
+    /// * `bl` - backlight pin
     /// * `size_x` - x axis resolution of the display in pixels
     /// * `size_y` - y axis resolution of the display in pixels
     ///
-    pub fn new(di: DI, rst: Option<RST>, size_x: u16, size_y: u16) -> Self {
+    pub fn new(di: DI, rst: Option<OUT>, bl: Option<OUT>, size_x: u16, size_y: u16) -> Self {
         Self {
             di,
             rst,
+            bl,
             size_x,
             size_y,
             orientation: Orientation::default(),
@@ -113,6 +123,12 @@ where
     ///
     pub fn init(&mut self, delay_source: &mut impl DelayUs<u32>) -> Result<(), Error<PinE>> {
         self.hard_reset(delay_source)?;
+        if let Some(bl) = self.bl.as_mut() {
+            bl.set_low().map_err(Error::Pin)?;
+            delay_source.delay_us(10_000);
+            bl.set_high().map_err(Error::Pin)?;
+        }
+
         self.write_command(Instruction::SWRESET)?; // reset display
         delay_source.delay_us(150_000);
         self.write_command(Instruction::SLPOUT)?; // turn off sleep
@@ -150,6 +166,21 @@ where
             delay_source.delay_us(10); // ensure the pin change will get registered
         }
 
+        Ok(())
+    }
+
+    pub fn set_backlight(
+        &mut self,
+        state: BacklightState,
+        delay_source: &mut impl DelayUs<u32>,
+    ) -> Result<(), Error<PinE>> {
+        if let Some(bl) = self.bl.as_mut() {
+            match state {
+                BacklightState::On => bl.set_high().map_err(Error::Pin)?,
+                BacklightState::Off => bl.set_low().map_err(Error::Pin)?,
+            }
+            delay_source.delay_us(10); // ensure the pin change will get registered
+        }
         Ok(())
     }
 
@@ -233,8 +264,8 @@ where
     /// Release resources allocated to this driver back.
     /// This returns the display interface and the RST pin deconstructing the driver.
     ///
-    pub fn release(self) -> (DI, Option<RST>) {
-        (self.di, self.rst)
+    pub fn release(self) -> (DI, Option<OUT>, Option<OUT>) {
+        (self.di, self.rst, self.bl)
     }
 
     fn write_command(&mut self, command: Instruction) -> Result<(), Error<PinE>> {


### PR DESCRIPTION
This pull request makes reset pin optional and gives control over a backlight pin. Those changes make it significantly easier to drive displays like this one: https://shop.pimoroni.com/products/1-54-spi-colour-square-lcd-240x240-breakout