### PR TITLE
Support Rgb565 and Bgr565

### DIFF
--- a/src/batch.rs
+++ b/src/batch.rs
@@ -4,25 +4,29 @@
 use crate::{Error, ST7789};
 use display_interface::WriteOnlyDataCommand;
 use embedded_graphics_core::{
-    pixelcolor::{raw::RawU16, Rgb565},
+    pixelcolor::raw::RawU16,
     prelude::*,
 };
 use embedded_hal::digital::v2::OutputPin;
 
-pub trait DrawBatch<DI, OUT, T, PinE>
+pub trait DrawBatch<DI, OUT, T, C, PinE>
 where
     DI: WriteOnlyDataCommand,
     OUT: OutputPin<Error = PinE>,
-    T: IntoIterator<Item = Pixel<Rgb565>>,
+    C: PixelColor + IntoStorage, RawU16: From<C>,
+    <C as embedded_graphics_core::pixelcolor::IntoStorage>::Storage: Clone,
+    T: IntoIterator<Item = Pixel<C>>,
 {
     fn draw_batch(&mut self, item_pixels: T) -> Result<(), Error<PinE>>;
 }
 
-impl<DI, OUT, T, PinE> DrawBatch<DI, OUT, T, PinE> for ST7789<DI, OUT>
+impl<DI, OUT, T, PinE, C> DrawBatch<DI, OUT, T, C, PinE> for ST7789<DI, OUT, C>
 where
     DI: WriteOnlyDataCommand,
     OUT: OutputPin<Error = PinE>,
-    T: IntoIterator<Item = Pixel<Rgb565>>,
+    T: IntoIterator<Item = Pixel<C>>,
+    C: PixelColor + IntoStorage, RawU16: From<C>,
+    <C as embedded_graphics_core::pixelcolor::IntoStorage>::Storage: Clone,
 {
     fn draw_batch(&mut self, item_pixels: T) -> Result<(), Error<PinE>> {
         //  Get the pixels for the item to be rendered.
@@ -66,7 +70,11 @@ type BlockColors = heapless::Vec<u16, MAX_BLOCK_SIZE>;
 
 /// Iterator for each Pixel Row in the pixel data. A Pixel Row consists of contiguous pixels on the same row.
 #[derive(Debug, Clone)]
-pub struct RowIterator<P: Iterator<Item = Pixel<Rgb565>>> {
+pub struct RowIterator<P, C>
+where
+P: Iterator<Item = Pixel<C>>,
+C: PixelColor + IntoStorage, RawU16: From<C>
+{
     /// Pixels to be batched into rows
     pixels: P,
     /// Start column number
@@ -128,11 +136,12 @@ pub struct PixelBlock {
 
 /// Batch the pixels into Pixel Rows, which are contiguous pixels on the same row.
 /// P can be any Pixel Iterator (e.g. a rectangle).
-fn to_rows<P>(pixels: P) -> RowIterator<P>
+fn to_rows<P, C>(pixels: P) -> RowIterator<P, C>
 where
-    P: Iterator<Item = Pixel<Rgb565>>,
+    P: Iterator<Item = Pixel<C>>,
+    C: PixelColor + IntoStorage, RawU16: From<C>
 {
-    RowIterator::<P> {
+    RowIterator::<P, C> {
         pixels,
         x_left: 0,
         x_right: 0,
@@ -144,9 +153,10 @@ where
 
 /// Batch the Pixel Rows into Pixel Blocks, which are contiguous Pixel Rows with the same start and end column number
 /// R can be any Pixel Row Iterator.
-fn to_blocks<R>(rows: R) -> BlockIterator<R>
+fn to_blocks<R, C>(rows: R) -> BlockIterator<R>
 where
     R: Iterator<Item = PixelRow>,
+    C: PixelColor + IntoStorage, RawU16: From<C>
 {
     BlockIterator::<R> {
         rows,
@@ -161,7 +171,11 @@ where
 
 /// Implement the Iterator for Pixel Rows.
 /// P can be any Pixel Iterator (e.g. a rectangle).
-impl<P: Iterator<Item = Pixel<Rgb565>>> Iterator for RowIterator<P> {
+impl<P, C> Iterator for RowIterator<P, C>
+where
+P: Iterator<Item = Pixel<C>>,
+C: PixelColor + IntoStorage, RawU16: From<C>
+{
     /// This Iterator returns Pixel Rows
     type Item = PixelRow;
 

--- a/src/batch.rs
+++ b/src/batch.rs
@@ -13,8 +13,7 @@ pub trait DrawBatch<DI, OUT, T, C, PinE>
 where
     DI: WriteOnlyDataCommand,
     OUT: OutputPin<Error = PinE>,
-    C: PixelColor + IntoStorage, RawU16: From<C>,
-    <C as embedded_graphics_core::pixelcolor::IntoStorage>::Storage: Clone,
+    C: PixelColor + IntoStorage + Clone, RawU16: From<C>,
     T: IntoIterator<Item = Pixel<C>>,
 {
     fn draw_batch(&mut self, item_pixels: T) -> Result<(), Error<PinE>>;
@@ -25,8 +24,7 @@ where
     DI: WriteOnlyDataCommand,
     OUT: OutputPin<Error = PinE>,
     T: IntoIterator<Item = Pixel<C>>,
-    C: PixelColor + IntoStorage, RawU16: From<C>,
-    <C as embedded_graphics_core::pixelcolor::IntoStorage>::Storage: Clone,
+    C: PixelColor + IntoStorage + Clone, RawU16: From<C>,
 {
     fn draw_batch(&mut self, item_pixels: T) -> Result<(), Error<PinE>> {
         //  Get the pixels for the item to be rendered.

--- a/src/graphics.rs
+++ b/src/graphics.rs
@@ -14,8 +14,7 @@ impl<DI, OUT, PinE, C> ST7789<DI, OUT, C>
 where
     DI: WriteOnlyDataCommand,
     OUT: OutputPin<Error = PinE>,
-    C: PixelColor + IntoStorage, RawU16: From<C>,
-    <C as embedded_graphics_core::pixelcolor::IntoStorage>::Storage: Clone
+    C: PixelColor + IntoStorage + Clone, RawU16: From<C>,
 {
     /// Returns the bounding box for the entire framebuffer.
     fn framebuffer_bounding_box(&self) -> Rectangle {
@@ -32,9 +31,8 @@ impl<DI, OUT, PinE, C> DrawTarget for ST7789<DI, OUT, C>
 where
     DI: WriteOnlyDataCommand,
     OUT: OutputPin<Error = PinE>,
-    C: PixelColor + IntoStorage, RawU16: From<C>,
-    <C as embedded_graphics_core::pixelcolor::IntoStorage>::Storage: Clone
-    {
+    C: PixelColor + IntoStorage + Clone, RawU16: From<C>,
+{
     type Error = Error<PinE>;
     type Color = C;
 
@@ -135,8 +133,7 @@ impl<DI, OUT, PinE, C> OriginDimensions for ST7789<DI, OUT, C>
 where
     DI: WriteOnlyDataCommand,
     OUT: OutputPin<Error = PinE>,
-    C: PixelColor + IntoStorage, RawU16: From<C>,
-    <C as embedded_graphics_core::pixelcolor::IntoStorage>::Storage: Clone
+    C: PixelColor + IntoStorage + Clone, RawU16: From<C>,
 {
     fn size(&self) -> Size {
         Size::new(self.size_x.into(), self.size_y.into()) // visible area, not RAM-pixel size

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -25,13 +25,13 @@ mod batch;
 
 ///
 /// ST7789 driver to connect to TFT displays.
+/// Support Rgb565 and Bgr565
 ///
 pub struct ST7789<DI, OUT, C>
 where
     DI: WriteOnlyDataCommand,
     OUT: OutputPin,
-    C: PixelColor + IntoStorage, RawU16: From<C>,
-    <C as embedded_graphics_core::pixelcolor::IntoStorage>::Storage: Clone
+    C: PixelColor + IntoStorage + Clone, RawU16: From<C>,
 {
     // Display interface
     di: DI,
@@ -98,8 +98,7 @@ impl<DI, OUT, PinE, C> ST7789<DI, OUT, C>
 where
     DI: WriteOnlyDataCommand,
     OUT: OutputPin<Error = PinE>,
-    C: PixelColor + IntoStorage, RawU16: From<C>,
-    <C as embedded_graphics_core::pixelcolor::IntoStorage>::Storage: Clone
+    C: PixelColor + IntoStorage + Clone, RawU16: From<C>,
 {
     ///
     /// Creates a new ST7789 driver instance

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -8,9 +8,12 @@ pub mod instruction;
 
 use crate::instruction::Instruction;
 use core::iter::once;
+use core::marker::PhantomData;
 
 use display_interface::DataFormat::{U16BEIter, U8Iter};
 use display_interface::WriteOnlyDataCommand;
+use embedded_graphics_core::pixelcolor::raw::RawU16;
+use embedded_graphics_core::prelude::{PixelColor, IntoStorage};
 use embedded_hal::blocking::delay::DelayUs;
 use embedded_hal::digital::v2::OutputPin;
 
@@ -23,10 +26,12 @@ mod batch;
 ///
 /// ST7789 driver to connect to TFT displays.
 ///
-pub struct ST7789<DI, OUT>
+pub struct ST7789<DI, OUT, C>
 where
     DI: WriteOnlyDataCommand,
     OUT: OutputPin,
+    C: PixelColor + IntoStorage, RawU16: From<C>,
+    <C as embedded_graphics_core::pixelcolor::IntoStorage>::Storage: Clone
 {
     // Display interface
     di: DI,
@@ -39,6 +44,8 @@ where
     size_y: u16,
     // Current orientation
     orientation: Orientation,
+
+    _phantom: PhantomData<C>,
 }
 
 ///
@@ -87,10 +94,12 @@ pub enum Error<PinE> {
     Pin(PinE),
 }
 
-impl<DI, OUT, PinE> ST7789<DI, OUT>
+impl<DI, OUT, PinE, C> ST7789<DI, OUT, C>
 where
     DI: WriteOnlyDataCommand,
     OUT: OutputPin<Error = PinE>,
+    C: PixelColor + IntoStorage, RawU16: From<C>,
+    <C as embedded_graphics_core::pixelcolor::IntoStorage>::Storage: Clone
 {
     ///
     /// Creates a new ST7789 driver instance
@@ -111,6 +120,7 @@ where
             size_x,
             size_y,
             orientation: Orientation::default(),
+            _phantom: PhantomData::default(),
         }
     }
 


### PR DESCRIPTION
Some module, namely M5Stick-C, has pixel color set to BGR565 instead of RGB565.
With pixel color in generic parameter, user may need to specify color when creating the instance, i.e.
```
let mut display = st7789::ST7789::<_, _, Bgr565>::new(...);
```