### PR TITLE
fix generic for bl vs rst pins

### DIFF
--- a/src/batch.rs
+++ b/src/batch.rs
@@ -9,19 +9,21 @@ use embedded_graphics_core::{
 };
 use embedded_hal::digital::v2::OutputPin;
 
-pub trait DrawBatch<DI, OUT, T, PinE>
+pub trait DrawBatch<DI, RST, BL, T, PinE>
 where
     DI: WriteOnlyDataCommand,
-    OUT: OutputPin<Error = PinE>,
+    RST: OutputPin<Error = PinE>,
+    BL: OutputPin<Error = PinE>,
     T: IntoIterator<Item = Pixel<Rgb565>>,
 {
     fn draw_batch(&mut self, item_pixels: T) -> Result<(), Error<PinE>>;
 }
 
-impl<DI, OUT, T, PinE> DrawBatch<DI, OUT, T, PinE> for ST7789<DI, OUT>
+impl<DI, RST, BL, T, PinE> DrawBatch<DI, RST, BL, T, PinE> for ST7789<DI, RST, BL>
 where
     DI: WriteOnlyDataCommand,
-    OUT: OutputPin<Error = PinE>,
+    RST: OutputPin<Error = PinE>,
+    BL: OutputPin<Error = PinE>,
     T: IntoIterator<Item = Pixel<Rgb565>>,
 {
     fn draw_batch(&mut self, item_pixels: T) -> Result<(), Error<PinE>> {

--- a/src/graphics.rs
+++ b/src/graphics.rs
@@ -11,10 +11,11 @@ use embedded_hal::digital::v2::OutputPin;
 use crate::{Error, Orientation, ST7789};
 use display_interface::WriteOnlyDataCommand;
 
-impl<DI, OUT, PinE> ST7789<DI, OUT>
+impl<DI, RST, BL, PinE> ST7789<DI, RST, BL>
 where
     DI: WriteOnlyDataCommand,
-    OUT: OutputPin<Error = PinE>,
+    RST: OutputPin<Error = PinE>,
+    BL: OutputPin<Error = PinE>,
 {
     /// Returns the bounding box for the entire framebuffer.
     fn framebuffer_bounding_box(&self) -> Rectangle {
@@ -27,10 +28,11 @@ where
     }
 }
 
-impl<DI, OUT, PinE> DrawTarget for ST7789<DI, OUT>
+impl<DI, RST, BL, PinE> DrawTarget for ST7789<DI, RST, BL>
 where
     DI: WriteOnlyDataCommand,
-    OUT: OutputPin<Error = PinE>,
+    RST: OutputPin<Error = PinE>,
+    BL: OutputPin<Error = PinE>,
 {
     type Error = Error<PinE>;
     type Color = Rgb565;
@@ -128,10 +130,11 @@ where
     }
 }
 
-impl<DI, OUT, PinE> OriginDimensions for ST7789<DI, OUT>
+impl<DI, RST, BL, PinE> OriginDimensions for ST7789<DI, RST, BL>
 where
     DI: WriteOnlyDataCommand,
-    OUT: OutputPin<Error = PinE>,
+    RST: OutputPin<Error = PinE>,
+    BL: OutputPin<Error = PinE>,
 {
     fn size(&self) -> Size {
         Size::new(self.size_x.into(), self.size_y.into()) // visible area, not RAM-pixel size

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -23,17 +23,18 @@ mod batch;
 ///
 /// ST7789 driver to connect to TFT displays.
 ///
-pub struct ST7789<DI, OUT>
+pub struct ST7789<DI, RST, BL>
 where
     DI: WriteOnlyDataCommand,
-    OUT: OutputPin,
+    RST: OutputPin,
+    BL: OutputPin,
 {
     // Display interface
     di: DI,
     // Reset pin.
-    rst: Option<OUT>,
+    rst: Option<RST>,
     // Backlight pin,
-    bl: Option<OUT>,
+    bl: Option<BL>,
     // Visible size (x, y)
     size_x: u16,
     size_y: u16,
@@ -87,10 +88,11 @@ pub enum Error<PinE> {
     Pin(PinE),
 }
 
-impl<DI, OUT, PinE> ST7789<DI, OUT>
+impl<DI, RST, BL, PinE> ST7789<DI, RST, BL>
 where
     DI: WriteOnlyDataCommand,
-    OUT: OutputPin<Error = PinE>,
+    RST: OutputPin<Error = PinE>,
+    BL: OutputPin<Error = PinE>,
 {
     ///
     /// Creates a new ST7789 driver instance
@@ -103,7 +105,7 @@ where
     /// * `size_x` - x axis resolution of the display in pixels
     /// * `size_y` - y axis resolution of the display in pixels
     ///
-    pub fn new(di: DI, rst: Option<OUT>, bl: Option<OUT>, size_x: u16, size_y: u16) -> Self {
+    pub fn new(di: DI, rst: Option<RST>, bl: Option<BL>, size_x: u16, size_y: u16) -> Self {
         Self {
             di,
             rst,
@@ -264,7 +266,7 @@ where
     /// Release resources allocated to this driver back.
     /// This returns the display interface and the RST pin deconstructing the driver.
     ///
-    pub fn release(self) -> (DI, Option<OUT>, Option<OUT>) {
+    pub fn release(self) -> (DI, Option<RST>, Option<BL>) {
         (self.di, self.rst, self.bl)
     }
 


### PR DESCRIPTION
Hi !

Thank you for making the st7789 Rust driver.

When using it with a TTGO Display in this project: https://github.com/pyaillet/ttgo-display-idf-rs

I faced a problem regarding generic parameters for the `reset` and `backlight` pins relying on the same generic parameter type.
I might be wrong, but I think it's a mistake because these two Pins won't be the same and so should rely on different generic parameters type.

So here is a PR to fix this. I was able to test it in my previous quoted project.