### PR TITLE
discard any pixels with negative coordinates to avoid a panic in later code

### DIFF
--- a/src/batch.rs
+++ b/src/batch.rs
@@ -190,6 +190,9 @@ impl<P: Iterator<Item = Pixel<Rgb565>>> Iterator for RowIterator<P> {
                 }
                 Some(Pixel(coord, color)) => {
                     //  If there is a pixel...
+                    if coord.x < 0 || coord.y < 0 {
+                        continue; // if we do not clip this here, the library panics later on
+                    }
                     let x = coord.x as u16;
                     let y = coord.y as u16;
                     let color = RawU16::from(color).into_inner();


### PR DESCRIPTION
I tried to draw some text at x,y = 1,1 , and got a panic inside batch.rs

It seems that the code to batch up pixels was converting an i16 to a u16, and when it came time to `self.y_bottom + 1` for` y=(-1 as u16)` that cause an arithmetic overflow and a panic.

This patch discards any pixels with coordinates <0