### PR TITLE
Fix instruction name typos

### DIFF
--- a/src/instruction.rs
+++ b/src/instruction.rs
@@ -18,11 +18,11 @@ pub enum Instruction {
     RAMWR = 0x2C,
     RAMRD = 0x2E,
     PTLAR = 0x30,
-    VSCRDER = 0x33,
+    VSCRDEF = 0x33,
     TEOFF = 0x34,
     TEON = 0x35,
     MADCTL = 0x36,
-    VSCAD = 0x37,
+    VSCSAD = 0x37,
     COLMOD = 0x3A,
     VCMOFSET = 0xC5,
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -136,7 +136,7 @@ where
         self.write_command(Instruction::SLPOUT)?; // turn off sleep
         delay_source.delay_us(10_000);
         self.write_command(Instruction::INVOFF)?; // turn off invert
-        self.write_command(Instruction::VSCRDER)?; // vertical scroll definition
+        self.write_command(Instruction::VSCRDEF)?; // vertical scroll definition
         self.write_data(&[0u8, 0u8, 0x14u8, 0u8, 0u8, 0u8])?; // 0 TSA, 320 VSA, 0 BSA
         self.write_command(Instruction::MADCTL)?; // left -> right, bottom -> top RGB
         self.write_data(&[0b0000_0000])?;
@@ -258,7 +258,7 @@ where
     /// * `offset` - scroll offset in pixels
     ///
     pub fn set_scroll_offset(&mut self, offset: u16) -> Result<(), Error<PinE>> {
-        self.write_command(Instruction::VSCAD)?;
+        self.write_command(Instruction::VSCSAD)?;
         self.write_data(&offset.to_be_bytes())
     }
 


### PR DESCRIPTION
These did not match the names in the datasheet.